### PR TITLE
Slow ClearRenderTarget fix

### DIFF
--- a/Play.h
+++ b/Play.h
@@ -3060,8 +3060,16 @@ namespace Play::Render
 	void ClearRenderTarget( Pixel colour ) 
 	{
 		ASSERT_RENDERTARGET;
+		static std::vector<Pixel> row = { colour };
+		
+		if (row[0].bits != colour.bits || row.size() != m_pRenderTarget->width)
+		{
+			row.assign(m_pRenderTarget->width, colour);
+		}
+
 		Pixel* pBuffEnd = m_pRenderTarget->pPixels + (m_pRenderTarget->width * m_pRenderTarget->height);
-		for (Pixel* pBuff = m_pRenderTarget->pPixels; pBuff < pBuffEnd; *pBuff++ = colour.bits);
+		for (Pixel* pBuff = m_pRenderTarget->pPixels; pBuff < pBuffEnd; pBuff += m_pRenderTarget->width)
+			memcpy(pBuff, row.data(), sizeof(Pixel) * m_pRenderTarget->width);
 		m_pRenderTarget->preMultiplied = false;
 	}
 


### PR DESCRIPTION
Because every pixel is cleared individually, the ClearRenderTarget function takes a few milliseconds with display windows equal to or larger than 1920x1080. The PR makes the clear function around 63x faster than the original. Instead of updating on a per-pixel basis, a pixel row is memcpy'd into the render target. The memory row is updated when the color or width changes.
